### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 all:
 	make ruby
 	make db
+	make reset-log
 
 init:
 	@sudo systemctl stop torb.perl
@@ -13,6 +14,20 @@ ruby:
 
 db:
 	@sudo systemctl restart mariadb
+mariadb:
+	@sudo systemctl restart mariadb.service
+h2o:
+	@sudo systemctl restart h2o.service
 
 systemctl-list:
 	systemctl list-unit-files --type=service
+alp:
+	cat /var/log/h2o/access.log | alp --aggregates="/api/users/.*","/api/events/.*","/admin/api/reports/events/.*" --sum -r
+pt-query-digest:
+	pt-query-digest --limit 10 /var/log/mariadb/mariadb-slow.log 
+
+reset-log:
+	@sudo rm /var/log/mariadb/mariadb-slow.log 
+	@sudo rm /var/log/h2o/access.log
+	make h2o
+	make mariadb


### PR DESCRIPTION

- `make pt-query-diges`

dbのスロークエリ集計

- `make alp`

h2oのログ集計

- `make reset-log`

ログファイル削除してh2oとmariadbを再起動
ちなみにmake allにもこのコマンドが追加された